### PR TITLE
Do not index and warn for outdated packages

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -121,6 +121,10 @@ helpers do
   def site_url
     config[:protocol] + host_with_port
   end
+
+  def is_hidden(package, version)
+      version['version'] != package.latest or @app.data.blacklist.include?(package.name)
+  end
 end
 
 ignore '/package.template.html.erb'
@@ -132,6 +136,6 @@ activate :livereload
 
 configure :development do
   set :host, '127.0.0.1'
-  set :port, Middleman::LiveReloadExtension.config.port
+  set :port, 4567
   set :protocol, 'http://'
 end

--- a/config.rb
+++ b/config.rb
@@ -123,7 +123,7 @@ helpers do
   end
 
   def is_hidden(package, version)
-      version['version'] != package.latest or @app.data.blacklist.include?(package.name)
+    version['version'] != package.latest or @app.data.blacklist.include?(package.name)
   end
 end
 

--- a/config.rb
+++ b/config.rb
@@ -136,6 +136,6 @@ activate :livereload
 
 configure :development do
   set :host, '127.0.0.1'
-  set :port, 4567
+  set :port, Middleman::LiveReloadExtension.config.port
   set :protocol, 'http://'
 end

--- a/source/_hidden.erb
+++ b/source/_hidden.erb
@@ -1,0 +1,3 @@
+<div class="alert alert-warning" role="alert">
+  <h4>Warning! <small>You are viewing an outdated version of the <%= package.name %> package</small></h4>
+</div>

--- a/source/layouts/layout.html.erb
+++ b/source/layouts/layout.html.erb
@@ -6,6 +6,16 @@
     <meta name="viewport"
           content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
+
+    <% if is_hidden(package, version) %>
+      <!--
+        Version: <%= version['version'] %>
+        Latest: <%= package.latest %>
+        Is blacklisted?: <%= data.blacklist.include?(package.name) %>
+      -->
+      <meta name="robots" content="noindex">
+    <% end %>
+
     <link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/2.10.0/github-markdown.css'></link>
 
     <%= stylesheet_link_tag "main" %>

--- a/source/layouts/layout.html.erb
+++ b/source/layouts/layout.html.erb
@@ -7,7 +7,7 @@
           content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
 
-    <% if is_hidden(package, version) %>
+    <% if defined?(package) and defined?(version) and is_hidden(package, version) %>
       <!--
         Version: <%= version['version'] %>
         Latest: <%= package.latest %>

--- a/source/package.template.html.erb
+++ b/source/package.template.html.erb
@@ -1,6 +1,5 @@
 <header class="header">
   <%= partial "nav" %>
-
   <section class="section orange iso section-slim" style="padding-bottom:66px;">
     <div class="section-content navigation" style="z-index: -1000"></div>
   </section>
@@ -9,6 +8,15 @@
 <main class="main">
   <section class="section white section-slim">
     <div class="section-content">
+
+      <% if is_hidden(package, version) %>
+      <div class="row">
+        <div class="col-md-10 col-md-offset-1">
+          <%= partial "hidden" %>
+        </div>
+      </div>
+      <% end %>
+
       <div class="row">
 
         <div class="col-md-8">


### PR DESCRIPTION
Closes #186

Example outdated package:
 - https://5eb96ea0c8c5770007d9891f--flamboyant-mcclintock-92ba2d.netlify.app/fishtown-analytics/dbt_utils/0.2.5/

Example blacklisted package (b/c we changed the name):
 - https://5eb96ea0c8c5770007d9891f--flamboyant-mcclintock-92ba2d.netlify.app/fishtown-analytics/dbt-utils/latest/

Example latest package:
 - https://5eb96ea0c8c5770007d9891f--flamboyant-mcclintock-92ba2d.netlify.app/fishtown-analytics/dbt_utils/latest/

All of these pages with "outdated" banners are tagged with a `noindex` meta tag, so they should hopefully not be indexed by search engines going forwards