### PR TITLE
Deprecate additional fishtown packages

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -123,7 +123,7 @@ helpers do
   end
 
   def is_hidden(package, version)
-    version['version'] != package.latest or @app.data.blocklist.include?(package.name)
+    version['version'] != package.latest or @app.data.blocklist.include?(package.namespace + "/" + package.name)
   end
 end
 

--- a/data/blocklist.json
+++ b/data/blocklist.json
@@ -1,6 +1,6 @@
 [
-    "bing-ads",
-    "dbt-event-logging",
-    "dbt-utils",
-    "facebook-ads"
+    "fishtown-analytics/bing-ads",
+    "fishtown-analytics/dbt-event-logging",
+    "fishtown-analytics/dbt-utils",
+    "fishtown-analytics/facebook-ads"
 ]

--- a/data/blocklist.json
+++ b/data/blocklist.json
@@ -2,5 +2,16 @@
     "fishtown-analytics/bing-ads",
     "fishtown-analytics/dbt-event-logging",
     "fishtown-analytics/dbt-utils",
-    "fishtown-analytics/facebook-ads"
+    "fishtown-analytics/facebook-ads",
+    "fishtown-analytics/bing_ads",
+    "fishtown-analytics/heap",
+    "fishtown-analytics/shopify",
+    "fishtown-analytics/zendesk",
+    "fishtown-analytics/outbrain",
+    "fishtown-analytics/taboola",
+    "fishtown-analytics/stripe",
+    "fishtown-analytics/recurly",
+    "fishtown-analytics/purecloud",
+    "fishtown-analytics/quickbooks",
+    "fishtown-analytics/ecommerce"
 ]

--- a/data/blocklist.json
+++ b/data/blocklist.json
@@ -13,5 +13,5 @@
     "fishtown-analytics/recurly",
     "fishtown-analytics/purecloud",
     "fishtown-analytics/quickbooks",
-    "fishtown-analytics/ecommerce"
+    "fishtown-analytics/fishtown_analytics_ecommerce"
 ]

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -42,7 +42,7 @@
             <ul style="list-style-type: disc; column-width: 250px; list-style-position: inside;">
                  <% packages = data.packages[org] %>
                  <% packages.each do |name, package| %>
-                    <% if not data.blocklist.include?(package) %>
+                    <% if not data.blocklist.include?(org + "/" + name) %>
                         <li>
                             <%= link_to(name, "/#{package['index'].namespace}/#{package['index'].name}/latest") %>
                         </li>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -42,7 +42,7 @@
             <ul style="list-style-type: disc; column-width: 250px; list-style-position: inside;">
                  <% packages = data.packages[org] %>
                  <% packages.each do |name, package| %>
-                    <% if not data.blocklist.include?(name) %>
+                    <% if not data.blocklist.include?(package) %>
                         <li>
                             <%= link_to(name, "/#{package['index'].namespace}/#{package['index'].name}/latest") %>
                         </li>

--- a/source/layouts/layout.html.erb
+++ b/source/layouts/layout.html.erb
@@ -11,7 +11,7 @@
       <!--
         Version: <%= version['version'] %>
         Latest: <%= package.latest %>
-        Is blocklisted?: <%= data.blocklist.include?(package.name) %>
+        Is blocklisted?: <%= data.blocklist.include?(package.namespace + "/" + package.name) %>
       -->
       <meta name="robots" content="noindex">
     <% end %>


### PR DESCRIPTION
First, I attempted to make this org-specific so I wouldn't accidentally blocklist a Fivetran package.

Then, I added  new packages to the list.

**Before:**
<img width="1268" alt="Screen Shot 2020-07-31 at 1 30 15 PM" src="https://user-images.githubusercontent.com/20294432/89061026-ffff4880-d331-11ea-9211-9077ab5b9904.png">

**After:**
<img width="1256" alt="Screen Shot 2020-07-31 at 1 33 00 PM" src="https://user-images.githubusercontent.com/20294432/89061247-62584900-d332-11ea-884f-217342db6831.png">


