### PR TITLE
Bump fishtown-analytics/logging [missed by HubCap]

### DIFF
--- a/data/packages/fishtown-analytics/logging/index.json
+++ b/data/packages/fishtown-analytics/logging/index.json
@@ -2,7 +2,7 @@
     "name": "logging",
     "namespace": "fishtown-analytics",
     "description": "dbt models for dbt-event-logging",
-    "latest": "0.4.1",
+    "latest": "0.4.2",
     "assets": {
         "logo": "logos/placeholder.svg"
     }

--- a/data/packages/fishtown-analytics/logging/versions/0.4.2.json
+++ b/data/packages/fishtown-analytics/logging/versions/0.4.2.json
@@ -1,0 +1,26 @@
+{
+    "id": "fishtown-analytics/logging/0.4.2",
+    "name": "logging",
+    "version": "0.4.2",
+    "published_at": "2020-10-19T16:46:40.000000+00:00",
+    "packages": [
+        {
+            "package": "fishtown-analytics/dbt_utils",
+            "version": [
+                ">=0.6.0",
+                "<0.7.0"
+            ]
+        }
+    ],
+    "works_with": [],
+    "_source": {
+        "type": "github",
+        "url": "https://github.com/fishtown-analytics/dbt-event-logging/tree/0.4.2/",
+        "readme": "https://raw.githubusercontent.com/fishtown-analytics/dbt-event-logging/0.4.2/README.md"
+    },
+    "downloads": {
+        "tarball": "https://codeload.github.com/fishtown-analytics/dbt-event-logging/tar.gz/0.4.2",
+        "format": "tgz",
+        "sha1": "11e8130214a58e5c8512e27a2634c97ee52fb99b"
+    }
+}


### PR DESCRIPTION
0.4.2 was released last October, and it was never picked up by HubCap: https://github.com/fishtown-analytics/dbt-event-logging/releases/tag/0.4.2

I manually updated the info in `0.4.2.json`, including the `sha1` hashing, based on the [logic here](https://github.com/fishtown-analytics/hubcap/blob/6060cfb0dfd594675b2916c7940a5d16782bbd70/hubcap.py#L84-L100). Is there a better way to have manually triggered the automated updater?